### PR TITLE
feat: Add StackBlitz button

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,0 +1,7 @@
+{
+  "startCommand": "npm run build; npm run start",
+  "env": {
+    "REACT_APP_BUTTER_CMS_API_KEY": "your_api_key",
+    "REACT_APP_BUTTER_CMS_PREVIEW": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ project to the provider of your choice.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Freact-starter-buttercms&env=REACT_APP_BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=react-starter-buttercms&repo-name=react-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20React%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Freact-starter-buttercms-demo.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=react-starter-buttercms) 
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/ButterCMS/react-starter-buttercms)
+
 ## 1. Installation
 
 First, clone the repo and install the dependencies by running `npm install`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ project to the provider of your choice.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Freact-starter-buttercms&env=REACT_APP_BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=react-starter-buttercms&repo-name=react-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20React%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Freact-starter-buttercms-demo.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=react-starter-buttercms) 
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/ButterCMS/react-starter-buttercms)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/ButterCMS/react-starter-buttercms/tree/feat/add-stackblitz-button)
 
 ## 1. Installation
 


### PR DESCRIPTION
Adds a StackBlitz button pointing to this branch since it requires `.stackblitzrc` file for correct configuration. Should point to main after merge of this PR.

## Limitations
- StackBlitz does not support static assets out of the box, that's why `.stackblitzrc` file is required ([relevant issue](https://github.com/stackblitz/core/issues/72))
- It also does not require dynamic env variables and therefore you either export API keys to the public or edit the code in `/src/utils/buttercmssdk.js` with correct API key on line `butterCMS = Butter("<your_api_key>", butterCmsPreview);` inside IDE of StackBlitz ([relevant issue](https://github.com/stackblitz/core/issues/1492))