### PR TITLE
Make direct urls work when deployed to vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,10 @@
 {
-    "outputDirectory": "build"
-}
+    "outputDirectory": "build",
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "rewrites": [
+      {
+        "source": "/(.*)",
+        "destination": "/index.html"
+      }
+    ]
+  }


### PR DESCRIPTION
Links within the starter project works when deployed to vercel, but the URLs within the website don't work on refresh https://tiugotech.slack.com/archives/C07GX0T4MJN/p1747317882779749?thread_ts=1747288801.390639&cid=C07GX0T4MJN